### PR TITLE
feat: add interactive session support

### DIFF
--- a/pylacus/__init__.py
+++ b/pylacus/__init__.py
@@ -11,7 +11,7 @@ if sys.version_info >= (3, 13):
 else:
     from deprecated import deprecated
 
-from .api import PyLacus, CaptureStatus, CaptureResponse, CaptureResponseJson  # noqa
+from .api import PyLacus, CaptureStatus, SessionStatus, CaptureResponse, CaptureResponseJson, InteractiveSessionResponse  # noqa
 
 
 @deprecated("Use lookyloo-models instead, the Pydantic models.")
@@ -42,6 +42,8 @@ class CaptureSettings(TypedDict, total=False):
     with_trusted_timestamps: bool
     allow_tracking: bool
     headless: bool
+    interactive: bool
+    interactive_ttl: int
     init_script: str
 
     force: bool | None
@@ -58,8 +60,10 @@ class CaptureSettings(TypedDict, total=False):
 __all__ = [
     'PyLacus',
     'CaptureStatus',
+    'SessionStatus',
     'CaptureResponse',
     'CaptureResponseJson',
+    'InteractiveSessionResponse',
     'CaptureSettings'
 ]
 

--- a/pylacus/api.py
+++ b/pylacus/api.py
@@ -22,6 +22,30 @@ from lookyloo_models import (Cookie, CaptureSettings, HttpCredentialsSettings,
 BROWSER = Literal['chromium', 'firefox', 'webkit']
 
 
+@unique
+class SessionStatus(IntEnum):
+    '''The status of an interactive session'''
+    UNKNOWN = -1
+    STARTING = 0
+    READY = 1
+    ERROR = 2
+    STOPPED = 3
+    EXPIRED = 4
+    CAPTURE_REQUESTED = 5
+
+
+class InteractiveSessionResponse(TypedDict, total=False):
+    '''Response from the interactive session status and finish endpoints.'''
+    uuid: str
+    status: str
+    raw_status: int
+    finish_requested: bool
+    view_url: str | None
+    created_at: int
+    expires_at: int
+    error: str | None
+
+
 class FramesResponse(TypedDict, total=False):
 
     name: str
@@ -145,6 +169,8 @@ class PyLacus():
                 with_trusted_timestamps: bool=False,
                 allow_tracking: bool=False,
                 headless: bool=True,
+                interactive: bool=False,
+                interactive_ttl: int=600,
                 init_script: str | None=None,
                 rendered_hostname_only: bool=True,
                 force: bool=False,
@@ -181,6 +207,8 @@ class PyLacus():
                 with_trusted_timestamps: bool=False,
                 allow_tracking: bool=False,
                 headless: bool=True,
+                interactive: bool=False,
+                interactive_ttl: int=600,
                 init_script: str | None=None,
                 rendered_hostname_only: bool=True,
                 force: bool=False,
@@ -205,7 +233,9 @@ class PyLacus():
                         'with_screenshot': with_screenshot, 'with_favicon': with_favicon,
                         'with_trusted_timestamps': with_trusted_timestamps,
                         'allow_tracking': allow_tracking, 'final_wait': final_wait,
-                        'headless': headless, 'init_script': init_script,
+                        'headless': headless, 'interactive': interactive,
+                        'interactive_ttl': interactive_ttl,
+                        'init_script': init_script,
                         'max_retries': max_retries, 'force': force,
                         'recapture_interval': recapture_interval,
                         'priority': priority, 'uuid': uuid
@@ -223,6 +253,16 @@ class PyLacus():
     def get_capture_status(self, uuid: str) -> CaptureStatus:
         '''Get the status of the capture.'''
         r = self.session.get(urljoin(self.root_url, str(PurePosixPath('capture_status', uuid))))
+        return r.json()
+
+    def get_interactive_session(self, uuid: str) -> InteractiveSessionResponse:
+        '''Get the status and public view details for an interactive capture session.'''
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('interactive', uuid))))
+        return r.json()
+
+    def request_interactive_capture(self, uuid: str) -> InteractiveSessionResponse:
+        '''Request a final capture of the current page for an interactive session.'''
+        r = self.session.post(urljoin(self.root_url, str(PurePosixPath('interactive', uuid, 'finish'))))
         return r.json()
 
     def _decode_response(self, capture: CaptureResponseJson) -> CaptureResponse:


### PR DESCRIPTION
Add client-side support for Lacus interactive capture sessions - new parameters on `enqueue()`, new typed responses, and two new API methods for managing interactive sessions.

### Changes

**New types** (`api.py`)
- `SessionStatus` IntEnum - mirrors LacusCore's session lifecycle states (`UNKNOWN`, `STARTING`, `READY`, `ERROR`, `STOPPED`, `EXPIRED`, `CAPTURE_REQUESTED`).
- `InteractiveSessionResponse` TypedDict - typed response for the interactive session endpoints (`uuid`, `status`, `raw_status`, `finish_requested`, `view_url`, `created_at`, `expires_at`, `error`).

**`enqueue()` changes** (`api.py`)
- Add `interactive: bool = False` and `interactive_ttl: int = 600` parameters to both the kwargs overload and the implementation.
- Both values are passed through to `CaptureSettings` for Pydantic validation (including the 1–600s TTL bound from lookyloo-models).

**New methods** (`api.py`)
- `get_interactive_session(uuid)` → `GET /interactive/<uuid>` - returns `InteractiveSessionResponse`.
- `request_interactive_capture(uuid)` → `POST /interactive/<uuid>/finish` - returns `InteractiveSessionResponse`.

**Deprecated TypedDict** (`__init__.py`)
- Add `interactive: bool` and `interactive_ttl: int` to the deprecated `CaptureSettings` TypedDict for completeness.

**Exports** (`__init__.py`)
- `SessionStatus` and `InteractiveSessionResponse` added to imports and `__all__`.

### Dependencies

Requires lookyloo-models with the `interactive`/`interactive_ttl` fields on `CaptureSettings` (companion PR: https://github.com/Lookyloo/lookyloo-models/pull/1).